### PR TITLE
Change the build and run commands

### DIFF
--- a/example03/README.md
+++ b/example03/README.md
@@ -105,12 +105,12 @@ CMD ["flask", "run", "--host=0.0.0.0"]
 
 ###### Build the Dockerfile with the build command
 ```
-docker build <container-name> .
+docker build --tag <container-name> .
 ```
 
 ###### Run the container with the run command and open the port for the web server
 ```
-docker run -p 5000:5000 <container-name> .
+docker run -p 5000:5000 <container-name>
 ```
 
 ## See the web Server


### PR DESCRIPTION
Commands as originally given did not work on OSX with Docker 18.03.1-ce-mac65 (24312). This change fixes it. I am not sure if this translates to other operating systems and docker versions or not.